### PR TITLE
Hacktoberfest/open

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ regex = "^0.1"
 rust-crypto = "^0.2"
 rustc-serialize = "^0.3"
 handlebars = "0.21"
+open = "^1.1"
 
 [package.metadata.deb]
 maintainer = "Iban Eguia <razican@protonmail.ch>"

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,6 +25,7 @@ pub struct Config {
     quiet: bool,
     force: bool,
     bench: bool,
+    open: bool,
     threads: u8,
     downloads_folder: String,
     dist_folder: String,
@@ -45,7 +46,8 @@ impl Config {
                verbose: bool,
                quiet: bool,
                force: bool,
-               bench: bool)
+               bench: bool,
+               open: bool)
                -> Result<Config> {
         let mut config: Config = Default::default();
         config.app_id = String::from(app_id);
@@ -53,6 +55,7 @@ impl Config {
         config.quiet = quiet;
         config.force = force;
         config.bench = bench;
+        config.open = open;
 
         if file_exists("/etc/config.toml") {
             try!(Config::load_from_file(&mut config, "/etc/config.toml", verbose));
@@ -71,7 +74,8 @@ impl Config {
                verbose: bool,
                quiet: bool,
                force: bool,
-               bench: bool)
+               bench: bool,
+               open: bool)
                -> Result<Config> {
         let mut config: Config = Default::default();
         config.app_id = String::from(app_id);
@@ -79,6 +83,7 @@ impl Config {
         config.quiet = quiet;
         config.force = force;
         config.bench = bench;
+        config.open = open;
 
         if file_exists("config.toml") {
             try!(Config::load_from_file(&mut config, "config.toml", verbose));
@@ -169,6 +174,14 @@ impl Config {
 
     pub fn set_bench(&mut self, bench: bool) {
         self.bench = bench;
+    }
+
+    pub fn is_open(&self) -> bool {
+        self.open
+    }
+
+    pub fn set_open(&mut self, open: bool) {
+        self.open = open;
     }
 
     pub fn get_threads(&self) -> u8 {
@@ -496,6 +509,7 @@ impl Default for Config {
                 quiet: false,
                 force: false,
                 bench: false,
+                open: false,
                 threads: 2,
                 downloads_folder: String::from("downloads"),
                 dist_folder: String::from("dist"),
@@ -523,6 +537,7 @@ impl Default for Config {
                 quiet: false,
                 force: false,
                 bench: false,
+                open: false,
                 threads: 2,
                 downloads_folder: String::from("downloads"),
                 dist_folder: String::from("dist"),
@@ -555,6 +570,7 @@ impl Default for Config {
                 quiet: false,
                 force: false,
                 bench: false,
+                open: false,
                 threads: 2,
                 downloads_folder: String::from("downloads"),
                 dist_folder: String::from("dist"),
@@ -582,6 +598,7 @@ impl Default for Config {
                 quiet: false,
                 force: false,
                 bench: false,
+                open: false,
                 threads: 2,
                 downloads_folder: String::from("downloads"),
                 dist_folder: String::from("dist"),
@@ -613,6 +630,7 @@ impl Default for Config {
             quiet: false,
             force: false,
             bench: false,
+            open: false,
             threads: 2,
             downloads_folder: String::from("downloads"),
             dist_folder: String::from("dist"),
@@ -708,6 +726,7 @@ mod tests {
         assert!(!config.is_quiet());
         assert!(!config.is_force());
         assert!(!config.is_bench());
+        assert!(!config.is_open());
         assert_eq!(config.get_threads(), 2);
         assert_eq!(config.get_downloads_folder(), "downloads");
         assert_eq!(config.get_dist_folder(), "dist");
@@ -767,12 +786,14 @@ mod tests {
         config.set_quiet(true);
         config.set_force(true);
         config.set_bench(true);
+        config.set_open(true);
 
         assert_eq!(config.get_app_id(), "test_app");
         assert!(config.is_verbose());
         assert!(config.is_quiet());
         assert!(config.is_force());
         assert!(config.is_bench());
+        assert!(config.is_open());
 
         if file_exists(format!("{}/{}.apk",
                                config.get_downloads_folder(),
@@ -793,7 +814,7 @@ mod tests {
         while !file_exists("config.toml.sample") {
             thread::sleep(Duration::from_millis(50));
         }
-        let config = Config::new("test_app", false, false, false, false).unwrap();
+        let config = Config::new("test_app", false, false, false, false, false).unwrap();
         let mut error_string = String::from("Configuration errors were found:\n");
         for error in config.get_errors() {
             error_string.push_str(&error);
@@ -818,7 +839,7 @@ mod tests {
         fs::rename("config.toml", "config.toml.bk").unwrap();
         fs::rename("config.toml.sample", "config.toml").unwrap();
 
-        let config = Config::new("test_app", false, false, false, false).unwrap();
+        let config = Config::new("test_app", false, false, false, false, false).unwrap();
         assert_eq!(config.get_threads(), 2);
         assert_eq!(config.get_downloads_folder(), "downloads");
         assert_eq!(config.get_dist_folder(), "dist");


### PR DESCRIPTION
Addressing the issue [#46](https://github.com/SUPERAndroidAnalyzer/super/issues/46).
Added the --open flag that opens the report index page in a browser once it is ready.
I have added a dependency to the project by using the [open crate](https://crates.io/crates/open) (as suggested in the issue comments). I am not sure as to what version I should use so I used ^1.1 .

The actual call to open the page does not write any message in case of success (I didn't think it is necessary). I can add a message for the case when verbose option is active, telling that the report has been successfully opened if you want.

I have tested it this way:
cargo run appname -- --open
or
./super appname --open

I hope this was the desired functionality.
