### PR TITLE
Replaced &str parameters with AsRef <str>

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -42,15 +42,16 @@ pub struct Config {
 
 impl Config {
     #[cfg(target_family = "unix")]
-    pub fn new(app_id: &str,
-               verbose: bool,
-               quiet: bool,
-               force: bool,
-               bench: bool,
-               open: bool)
-               -> Result<Config> {
+    pub fn new<S: AsRef<str>>(
+                app_id: S,
+                verbose: bool,
+                quiet: bool,
+                force: bool,
+                bench: bool,
+                open: bool)
+                -> Result<Config> {
         let mut config: Config = Default::default();
-        config.app_id = String::from(app_id);
+        config.app_id = String::from(app_id.as_ref());
         config.verbose = verbose;
         config.quiet = quiet;
         config.force = force;
@@ -70,15 +71,16 @@ impl Config {
     }
 
     #[cfg(target_family = "windows")]
-    pub fn new(app_id: &str,
-               verbose: bool,
-               quiet: bool,
-               force: bool,
-               bench: bool,
-               open: bool)
-               -> Result<Config> {
+    pub fn new<S: AsRef<str>>(
+                app_id: S,
+                verbose: bool,
+                quiet: bool,
+                force: bool,
+                bench: bool,
+                open: bool)
+                -> Result<Config> {
         let mut config: Config = Default::default();
-        config.app_id = String::from(app_id);
+        config.app_id = String::from(app_id.as_ref());
         config.verbose = verbose;
         config.quiet = quiet;
         config.force = force;
@@ -140,8 +142,8 @@ impl Config {
         self.app_id.as_str()
     }
 
-    pub fn set_app_id(&mut self, app_id: &str) {
-        self.app_id = String::from(app_id);
+    pub fn set_app_id<S: AsRef<str>>(&mut self, app_id: S) {
+        self.app_id = String::from(app_id.as_ref());
     }
 
     pub fn is_verbose(&self) -> bool {
@@ -481,7 +483,7 @@ impl Config {
                                         .insert(PermissionConfig::new(permission,
                                                                       criticity,
                                                                       label,
-                                                                      description.as_str()));
+                                                                      &String::from(description.as_ref())));
                                 }
                             }
                         }
@@ -677,16 +679,17 @@ impl PartialOrd for PermissionConfig {
 }
 
 impl PermissionConfig {
-    fn new(permission: Permission,
-           criticity: Criticity,
-           label: &str,
-           description: &str)
-           -> PermissionConfig {
+    fn new<S: AsRef<str>>(
+            permission: Permission,
+            criticity: Criticity,
+            label: S,
+            description: S)
+            -> PermissionConfig {
         PermissionConfig {
             permission: permission,
             criticity: criticity,
-            label: String::from(label),
-            description: String::from(description),
+            label: String::from(label.as_ref()),
+            description: String::from(description.as_ref()),
         }
     }
 

--- a/src/results/mod.rs
+++ b/src/results/mod.rs
@@ -94,20 +94,20 @@ impl Results {
         }
     }
 
-    pub fn set_app_package(&mut self, package: &str) {
-        self.app_package = String::from(package);
+    pub fn set_app_package<S: AsRef<str>>(&mut self, package: S) {
+        self.app_package = String::from(package.as_ref());
     }
 
-    pub fn set_app_label(&mut self, label: &str) {
-        self.app_label = String::from(label);
+    pub fn set_app_label<S: AsRef<str>>(&mut self, label: S) {
+        self.app_label = String::from(label.as_ref());
     }
 
-    pub fn set_app_description(&mut self, description: &str) {
-        self.app_description = String::from(description);
+    pub fn set_app_description<S: AsRef<str>>(&mut self, description: S) {
+        self.app_description = String::from(description.as_ref());
     }
 
-    pub fn set_app_version(&mut self, version: &str) {
-        self.app_version = String::from(version);
+    pub fn set_app_version<S: AsRef<str>>(&mut self, version: S) {
+        self.app_version = String::from(version.as_ref());
     }
 
     pub fn set_app_version_num(&mut self, version: i32) {
@@ -807,9 +807,9 @@ impl Results {
         Ok(())
     }
 
-    fn html_escape(code: &str) -> String {
+    fn html_escape<S: AsRef<str>>(code: S) -> String {
         let mut res = String::new();
-        for c in code.chars() {
+        for c in code.as_ref().chars() {
             match c {
                 '<' => res.push_str("&lt;"),
                 '>' => res.push_str("&gt;"),

--- a/src/results/utils.rs
+++ b/src/results/utils.rs
@@ -224,9 +224,9 @@ pub struct Benchmark {
 
 impl Benchmark {
     /// Creates a new benchmark
-    pub fn new(label: &str, duration: Duration) -> Benchmark {
+    pub fn new<S: AsRef<str>>(label: S, duration: Duration) -> Benchmark {
         Benchmark {
-            label: String::from(label),
+            label: String::from(label.as_ref()),
             duration: duration,
         }
     }

--- a/src/static_analysis/certificate.rs
+++ b/src/static_analysis/certificate.rs
@@ -9,8 +9,8 @@ use chrono::{Local, Datelike};
 use {Error, Config, Criticity, Result, print_error, print_vulnerability, print_warning};
 use results::{Results, Vulnerability};
 
-fn parse_month(month_str: &str) -> u32 {
-    let month_number = match month_str {
+fn parse_month<S: AsRef<str>>(month_str: S) -> u32 {
+    let month_number = match month_str.as_ref() {
         "Jan" => 1,
         "Feb" => 2,
         "Mar" => 3,

--- a/src/static_analysis/code.rs
+++ b/src/static_analysis/code.rs
@@ -254,9 +254,9 @@ fn analyze_file<P: AsRef<Path>>(path: P,
     Ok(())
 }
 
-fn get_line_for(index: usize, text: &str) -> usize {
+fn get_line_for<S: AsRef<str>>(index: usize, text: S) -> usize {
     let mut line = 0;
-    for (i, c) in text.char_indices() {
+    for (i, c) in text.as_ref().char_indices() {
         if i == index {
             break;
         }
@@ -605,29 +605,29 @@ mod tests {
     use regex::Regex;
     use super::{Rule, load_rules};
 
-    fn check_match(text: &str, rule: &Rule) -> bool {
-        if rule.get_regex().is_match(text) {
+    fn check_match<S: AsRef<str>>(text: S, rule: &Rule) -> bool {
+        if rule.get_regex().is_match(text.as_ref()) {
             for white in rule.get_whitelist() {
-                if white.is_match(text) {
-                    let (s, e) = white.find(text).unwrap();
+                if white.is_match(text.as_ref()) {
+                    let (s, e) = white.find(text.as_ref()).unwrap();
                     println!("Whitelist '{}' matches the text '{}' in '{}'",
                              white.as_str(),
-                             text,
-                             &text[s..e]);
+                             text.as_ref(),
+                             &text.as_ref()[s..e]);
                     return false;
                 }
             }
             match rule.get_forward_check() {
                 None => {
-                    let (s, e) = rule.get_regex().find(text).unwrap();
+                    let (s, e) = rule.get_regex().find(text.as_ref()).unwrap();
                     println!("The regular expression '{}' matches the text '{}' in '{}'",
                              rule.get_regex(),
-                             text,
-                             &text[s..e]);
+                             text.as_ref(),
+                             &text.as_ref()[s..e]);
                     true
                 }
                 Some(check) => {
-                    let caps = rule.get_regex().captures(text).unwrap();
+                    let caps = rule.get_regex().captures(text.as_ref()).unwrap();
 
                     let fcheck1 = caps.name("fc1");
                     let fcheck2 = caps.name("fc2");
@@ -642,17 +642,17 @@ mod tests {
                     }
 
                     let regex = Regex::new(r.as_str()).unwrap();
-                    if regex.is_match(text) {
-                        let (s, e) = regex.find(text).unwrap();
+                    if regex.is_match(text.as_ref()) {
+                        let (s, e) = regex.find(text.as_ref()).unwrap();
                         println!("The forward check '{}'  matches the text '{}' in '{}'",
                                  regex.as_str(),
-                                 text,
-                                 &text[s..e]);
+                                 text.as_ref(),
+                                 &text.as_ref()[s..e]);
                         true
                     } else {
                         println!("The forward check '{}' does not match the text '{}'",
                                  regex.as_str(),
-                                 text);
+                                 text.as_ref());
                         false
                     }
                 }
@@ -660,7 +660,7 @@ mod tests {
         } else {
             println!("The regular expression '{}' does not match the text '{}'",
                      rule.get_regex(),
-                     text);
+                     text.as_ref());
             false
         }
     }

--- a/src/static_analysis/manifest.rs
+++ b/src/static_analysis/manifest.rs
@@ -490,8 +490,8 @@ impl Manifest {
         Ok(manifest)
     }
 
-    fn set_code(&mut self, code: &str) {
-        self.code = String::from(code);
+    fn set_code<S: AsRef<str>>(&mut self, code: S) {
+        self.code = String::from(code.as_ref());
     }
 
     pub fn get_code(&self) -> &str {
@@ -502,8 +502,8 @@ impl Manifest {
         self.package.as_str()
     }
 
-    fn set_package(&mut self, package: &str) {
-        self.package = String::from(package);
+    fn set_package<S: AsRef<str>>(&mut self, package: S) {
+        self.package = String::from(package.as_ref());
     }
 
     pub fn get_version_number(&self) -> i32 {
@@ -518,24 +518,24 @@ impl Manifest {
         self.version_str.as_str()
     }
 
-    fn set_version_str(&mut self, version_str: &str) {
-        self.version_str = String::from(version_str);
+    fn set_version_str<S: AsRef<str>>(&mut self, version_str: S) {
+        self.version_str = String::from(version_str.as_ref());
     }
 
     pub fn get_label(&self) -> &str {
         self.label.as_str()
     }
 
-    fn set_label(&mut self, label: &str) {
-        self.label = String::from(label);
+    fn set_label<S: AsRef<str>>(&mut self, label: S) {
+        self.label = String::from(label.as_ref());
     }
 
     pub fn get_description(&self) -> &str {
         self.description.as_str()
     }
 
-    fn set_description(&mut self, description: &str) {
-        self.description = String::from(description);
+    fn set_description<S: AsRef<str>>(&mut self, description: S) {
+        self.description = String::from(description.as_ref());
     }
 
     pub fn get_min_sdk(&self) -> i32 {
@@ -643,9 +643,9 @@ impl FromStr for InstallLocation {
     }
 }
 
-fn get_line(code: &str, haystack: &str) -> Result<usize> {
-    for (i, line) in code.lines().enumerate() {
-        if line.contains(haystack) {
+fn get_line<S: AsRef<str>>(code: S, haystack: S) -> Result<usize> {
+    for (i, line) in code.as_ref().lines().enumerate() {
+        if line.contains(haystack.as_ref()) {
             return Ok(i);
         }
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -60,9 +60,9 @@ pub fn print_vulnerability<S: AsRef<str>>(text: S, criticity: Criticity) {
     sleep(Duration::from_millis(200));
 }
 
-pub fn get_code(code: &str, s_line: usize, e_line: usize) -> String {
+pub fn get_code<S: AsRef<str>>(code: S, s_line: usize, e_line: usize) -> String {
     let mut result = String::new();
-    for (i, text) in code.lines().enumerate() {
+    for (i, text) in code.as_ref().lines().enumerate() {
         if i >= (e_line + 5) {
             break;
         } else if (s_line >= 5 && i > s_line - 5) || (s_line < 5 && i < s_line + 5) {
@@ -77,7 +77,7 @@ pub fn file_exists<P: AsRef<Path>>(path: P) -> bool {
     path.as_ref().exists()
 }
 
-pub fn get_string(label: &str, config: &Config) -> Result<String> {
+pub fn get_string<S: AsRef<str>>(label: S, config: &Config) -> Result<String> {
     let mut file = try!(fs::File::open({
         let path = format!("{}/{}/res/values-en/strings.xml",
                            config.get_dist_folder(),
@@ -104,7 +104,7 @@ pub fn get_string(label: &str, config: &Config) -> Result<String> {
                 match name.local_name.as_str() {
                     "string" => {
                         for attr in attributes {
-                            if attr.name.local_name == "name" && attr.value == label {
+                            if attr.name.local_name == "name" && attr.value == label.as_ref() {
                                 found = true;
                             }
                         }


### PR DESCRIPTION
Addressing issue [#53](https://github.com/SUPERAndroidAnalyzer/super/issues/53)
Replaced the &str parameters with AsRef<str>.
