### PR TITLE
Add paths when there is some error creating them

### DIFF
--- a/src/decompilation.rs
+++ b/src/decompilation.rs
@@ -40,7 +40,10 @@ pub fn decompress<P: AsRef<Path>>(config: &mut Config, package: P) -> Result<()>
         let mut apk = Apk::new(package.as_ref())
             .chain_err(|| "error loading apk file")?;
         apk.export(&path, true)
-            .chain_err(|| "could not decompress the apk file")?;
+            .chain_err(|| {
+                           format!("could not decompress the apk file. Tried to decompile at: {}",
+                                   path.display())
+                       })?;
 
         if config.is_verbose() {
             println!("{}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -250,7 +250,10 @@ fn analyze_package<P: AsRef<Path>>(package: P,
     let report_start = Instant::now();
     results
         .generate_report(config, &package_name)
-        .chain_err(|| "There was an error generating the results report")?;
+        .chain_err(|| {
+            format!("There was an error generating the results report. Tried to generate at: {}",
+                    config.get_results_folder().join(&package_name).display())
+        })?;
 
     if config.is_verbose() {
         println!("Everything went smoothly, now you can check all the results.");


### PR DESCRIPTION
Adding paths to error stack to make the errors more meaningful.

Feel free to close it if you think that is not necessary.